### PR TITLE
fix alphabetical order

### DIFF
--- a/src/Services/LocationReferenceService.php
+++ b/src/Services/LocationReferenceService.php
@@ -39,6 +39,12 @@ class LocationReferenceService
 
         $countries = array_merge($countries, $countriesToAdd);
 
+        usort($countries, function($a, $b){
+            $at = iconv('UTF-8', 'ASCII//TRANSLIT', $a['name']);
+            $bt = iconv('UTF-8', 'ASCII//TRANSLIT', $b['name']);
+            return strcmp($at, $bt);
+        });
+
         return $countries;
     }
 


### PR DESCRIPTION
This is a potential fix to two issues regarding the order of country names. 

First, context. The LocationReferenceService::countriesMasterList method provides the "master" list to other methods, and so in there we centralize any manipulation to the countries-list that we want to be universal. This includes adding "user-defined" countries like Kosovo—which should be in the ISO 3166 standard but is not yet for largely bureaucratic reasons.

But there was an issue. The user-defined countries didn't appear in alphabetical order as they should. Applying a sort function like asort (sort low-to-high, by value, discard indexes) fixes the alphabetization for user-defined countries but then a new issue arose. Namely, "Åland Islands" (NOT a user-defined country) is now at the bottom of the list. Previously it was in the right location—between Afghanistan and Albania.

[This fix (stackoverflow.com/a/10649560)](https://stackoverflow.com/a/10649560/1409396) works, but I'm not familar with _[iconv](https://www.php.net/manual/en/function.iconv.php)_ and so don't want to just throw it up on production without groking it a little better.

It seems like a potentially dispropotionate time-sink for such a little thing, but this iconv function does look very very useful and I would like to be able to use it in the future to help solve the kinds of localization and character-encoding issues that have come up before and that I'm sure we'll see plenty more of.

What do ya'll think? Probably fine? Definitely fine? Warrants looking into out PHP config? Your thoughts would be much appreciated.

Thanks,

Jon M.